### PR TITLE
Update VIMTern to use Slack webhooks

### DIFF
--- a/plugin/default.intrn
+++ b/plugin/default.intrn
@@ -1,7 +1,8 @@
 %YAML 1.2
 ---
 Slack:
-    token: 0000-0000 # Get one at https://api.slack.com/web#authentication
+    # Replace the line below with your webhook integration URI
+    uri: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
     channel: "#general"
     username: VIMTern
     icon_emoji: ":robot_face:"

--- a/plugin/default.intrn
+++ b/plugin/default.intrn
@@ -3,7 +3,7 @@
 Slack:
     # Replace the line below with your webhook integration URI
     uri: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
-    channel: "#general"
+    channel: "#general" # Can be either #channel or @username
     username: VIMTern
     icon_emoji: ":robot_face:"
 

--- a/plugin/vimtern.py
+++ b/plugin/vimtern.py
@@ -13,7 +13,7 @@ VERBOSE = False
 try:
     import requests
 except ImportError:
-    print "Unable to import requests. Run `pip install requests` and try again."
+    print "Unable to import requests. Run `pip install requests`."
     exit(1)
 
 
@@ -63,13 +63,15 @@ def vimtern_do(msg, intrn_file):
     # Create and send POST request to Slack webhook
     slack_uri = config['Slack']['uri']
     try:
-        r = requests.post(slack_uri, data=payload, headers={'Content-type': 'application/json'})
+        r = requests.post(slack_uri, data=payload, headers={
+                          'Content-type': 'application/json'})
         r.raise_for_status()
     except requests.exceptions.ConnectionError:
         print "Could not establish connection to Slack."
         exit(1)
-    except requests.exceptions.HTTPError:
+    except requests.exceptions.HTTPError as err:
         print "Slack API request was not successful."
+        print err.message
         exit(1)
     except requests.exceptions.Timeout:
         print "Slack API request timed out."

--- a/plugin/vimtern.py
+++ b/plugin/vimtern.py
@@ -5,14 +5,15 @@ VIMTern.py dispatch work to your intern via Slack from the command line.
 from random import randint
 from sys import exit, argv
 import argparse
+import json
 import yaml  # To load the intrn file
 
 VERBOSE = False
 
 try:
-    from slackclient import SlackClient
+    import requests
 except ImportError:
-    print "Unable to import the SlackClient."
+    print "Unable to import requests. Run `pip install requests` and try again."
     exit(1)
 
 
@@ -45,17 +46,33 @@ def vimtern_do(msg, intrn_file):
         print "vimtern_do: msg is not a string."
         print "msg: ", msg
         exit(1)
-    msg = msg.replace('"', '').strip()
 
-    sc = SlackClient(config["Slack"]["token"])
-    if VERBOSE:
-        print ">" * 5, msg
+    # Build JSON message payload
+    msg = msg.replace('"', '').strip()
     channel = config["Slack"]["channel"]
+    username = config["Slack"]["username"]
     icon_emoji = config["Slack"]["icon_emoji"]
-    sc.api_call("chat.postMessage",
-                channel=channel,
-                text=msg,
-                username=config["Slack"]["username"], icon_emoji=icon_emoji)
+    payload = json.dumps({
+        "text": msg,
+        "channel": channel,
+        "username": username,
+        "icon_emoji": icon_emoji
+    })
+
+    # Create and send POST request to Slack webhook
+    slack_uri = config['Slack']['uri']
+    try:
+        r = requests.post(slack_uri, data=payload, headers={'Content-type': 'application/json'})
+        r.raise_for_status()
+    except requests.exceptions.ConnectionError:
+        print "Could not establish connection to Slack."
+        exit(1)
+    except requests.exceptions.HTTPError:
+        print "Slack API request was not successful."
+        exit(1)
+    except requests.exceptions.Timeout:
+        print "Slack API request timed out."
+        exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Instead of using the Slack API library and having to create a Slack app within an organization, simply use the existing webhook framework and a simple `POST` request with a JSON payload to send channel or DMs with VIMtern.